### PR TITLE
Widget 3365 remove redundant api calls

### DIFF
--- a/backend/ota_demo_api/routers/search.py
+++ b/backend/ota_demo_api/routers/search.py
@@ -77,10 +77,12 @@ async def search_api(
 
     Location filters:
     - city and country
+
     OR
+
     - lat, long and radius
 
-    Please specify either city and country or lat, long, radius, specifying both triggers a validation error.
+    Please specify either (city, country) or (lat, long, radius), specifying both triggers a validation error.
 
     Optional filters: categories, trip_type, hotel_types, language.
 

--- a/backend/ota_demo_api/view_model/cluster_search_result.py
+++ b/backend/ota_demo_api/view_model/cluster_search_result.py
@@ -18,6 +18,10 @@ class ClusterSearchResult(BaseModel):
     categories: Dict[str, DataPoint]
     hotel_types: Dict[str, DataPoint]
     overall_match: bool
+    city: str
+    country: str
+    latitude: float
+    longitude: float
 
     class Config:
         orm_mode = True

--- a/backend/ota_demo_api/view_model/search_response.py
+++ b/backend/ota_demo_api/view_model/search_response.py
@@ -2,16 +2,6 @@ from typing import Optional, List, Dict, Tuple
 from pydantic import BaseModel
 
 
-class ReviewsDistributionResponse(BaseModel):
-    count: int
-    stars: int
-
-
-class TravelerTypesDistributionResponse(BaseModel):
-    count: int
-    trip_type: str
-
-
 class BadgeHighlightModel(BaseModel):
     text: str
     confidence: float
@@ -120,8 +110,6 @@ class HotelResponse(BaseModel):
     relevant_now: Optional[RelevantNowResponse]
     categories: Optional[List[CategoryResponse]]
     badges: Optional[List[BadgeResponse]]
-    reviews_distribution: Optional[List[ReviewsDistributionResponse]]
-    traveler_types_distribution: Optional[List[TravelerTypesDistributionResponse]]
     match: MatchResponse
     distance_from_center: Optional[str]
     coordinates: Optional[Tuple[float, float]]

--- a/frontend/details.html
+++ b/frontend/details.html
@@ -70,7 +70,7 @@ class HotelNameLocation extends React.Component{
     const { image, addresses, coordinates, name} = this.state;
 
     const hotelImage = { backgroundImage: `url(${image})`, };
-    const mapLink = coordinates ? `https://www.google.com/maps?q=${coordinates[1]},${coordinates[0]}` : "javascript:void(0)";
+    const mapLink = coordinates ? `https://www.google.com/maps?q=${coordinates[0]},${coordinates[1]}` : "javascript:void(0)";
 
     return <header style={hotelImage}>
       <div className="container">

--- a/frontend/includes/detail.js
+++ b/frontend/includes/detail.js
@@ -57,7 +57,7 @@ class HotelNameLocation extends React.Component{
     const { image, addresses, coordinates, name} = this.state;
 
     const hotelImage = { backgroundImage: `url(${image})`, };
-    const mapLink = coordinates ? `https://www.google.com/maps?q=${coordinates[1]},${coordinates[0]}` : "javascript:void(0)";
+    const mapLink = coordinates ? `https://www.google.com/maps?q=${coordinates[0]},${coordinates[1]}` : "javascript:void(0)";
 
     return <header style={hotelImage}>
       <div className="container">

--- a/frontend/results.html
+++ b/frontend/results.html
@@ -1090,7 +1090,7 @@ function addMarker(tyId, scoreDescription, lat, lon, popupText) {
     }
     cleanMarker(tyId);
 
-    var marker = L.marker([lon, lat], {icon: getIcon(scoreDescription)})
+    var marker = L.marker([lat, lon], {icon: getIcon(scoreDescription)})
         .bindPopup(popupText);
     marker.tyId = tyId;
 


### PR DESCRIPTION
* In preparation of using the db instead of API calls, firstly the redundant API calls that deliver no value at the moment in the UI are removed from the backend.
* The API will not longer limit the search results to hotels that have at least one of the specified categories/hotel types