### PR TITLE
Fix antd version to v4

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -145,7 +145,7 @@ ReactDOM.render(<HomePage />, document.getElementById('index-page'))
     <script type="text/javascript" src="//unpkg.com/react@17/umd/react.production.min.js"></script>
     <script type="text/javascript" src="//unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
     <script type="text/javascript" src="//unpkg.com/@babel/standalone@7.13.9/babel.min.js"></script>
-    <script type="text/javascript" src="//unpkg.com/antd/dist/antd.min.js"></script>
-    <link rel="stylesheet" href="//unpkg.com/antd/dist/antd.min.css"/>
+    <script type="text/javascript" src="//unpkg.com/antd@^4.24.7/dist/antd.min.js"></script>
+    <link rel="stylesheet" href="//unpkg.com/antd@^4.24.7/dist/antd.min.css"/>
   </body>
 </html>

--- a/frontend/index.pug
+++ b/frontend/index.pug
@@ -26,5 +26,5 @@ html
 		script(type="text/javascript" src="//unpkg.com/react@17/umd/react.production.min.js")
 		script(type="text/javascript" src="//unpkg.com/react-dom@17/umd/react-dom.production.min.js")
 		script(type="text/javascript" src="//unpkg.com/@babel/standalone@7.13.9/babel.min.js")
-		script(type="text/javascript" src="//unpkg.com/antd/dist/antd.min.js")
-		link(rel="stylesheet", href="//unpkg.com/antd/dist/antd.min.css")
+		script(type="text/javascript" src="//unpkg.com/antd@^4.24.7/dist/antd.min.js")
+		link(rel="stylesheet", href="//unpkg.com/antd@^4.24.7/dist/antd.min.css")

--- a/frontend/results.html
+++ b/frontend/results.html
@@ -1331,8 +1331,8 @@ function cleanMarker(ty_id) {
     <script type="text/javascript" src="//unpkg.com/react@17/umd/react.production.min.js"></script>
     <script type="text/javascript" src="//unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
     <script type="text/javascript" src="//unpkg.com/@babel/standalone@7.13.9/babel.min.js"></script>
-    <script type="text/javascript" src="//unpkg.com/antd/dist/antd.min.js"></script>
-    <link rel="stylesheet" href="//unpkg.com/antd/dist/antd.min.css"/>
+    <script type="text/javascript" src="//unpkg.com/antd@^4.24.7/dist/antd.min.js"></script>
+    <link rel="stylesheet" href="//unpkg.com/antd@^4.24.7/dist/antd.min.css"/>
     <script type="text/javascript" src="//unpkg.com/leaflet@1.7.1/dist/leaflet.js" integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA==" crossorigin=""></script>
     <link rel="stylesheet" href="//unpkg.com/leaflet@1.7.1/dist/leaflet.css" integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A==" crossorigin=""/>
   </body>

--- a/frontend/results.pug
+++ b/frontend/results.pug
@@ -27,8 +27,8 @@ html
 		script(type="text/javascript" src="//unpkg.com/react@17/umd/react.production.min.js")
 		script(type="text/javascript" src="//unpkg.com/react-dom@17/umd/react-dom.production.min.js")
 		script(type="text/javascript" src="//unpkg.com/@babel/standalone@7.13.9/babel.min.js")
-		script(type="text/javascript" src="//unpkg.com/antd/dist/antd.min.js")
-		link(rel="stylesheet", href="//unpkg.com/antd/dist/antd.min.css")
+		script(type="text/javascript" src="//unpkg.com/antd@^4.24.7/dist/antd.min.js")
+		link(rel="stylesheet", href="//unpkg.com/antd@^4.24.7/dist/antd.min.css")
 
 		script(type="text/javascript" src="//unpkg.com/leaflet@1.7.1/dist/leaflet.js" integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA==" crossorigin="")
 		link(rel="stylesheet", href="//unpkg.com/leaflet@1.7.1/dist/leaflet.css" integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A==" crossorigin="")


### PR DESCRIPTION
Frontend breaks when using antd version 5 as the `antd.min.css` is missing
https://unpkg.com/browse/antd@5.1.7/dist/
We can work around it by fixing the library version to v4.
https://unpkg.com/browse/antd@4.24.7/dist/